### PR TITLE
Add CVGenio case study and improve responsive theming

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,23 @@
   <!-- Title -->
   <title>AlfaroFernando Portfolio</title>
 
+  <script>
+    (function () {
+      const storageKey = 'portfolio-theme';
+      try {
+        const stored = window.localStorage.getItem(storageKey);
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = stored || (prefersDark ? 'dark' : 'light');
+        const root = document.documentElement;
+        root.classList.toggle('dark', theme === 'dark');
+        root.setAttribute('data-theme', theme);
+        root.style.colorScheme = theme === 'dark' ? 'dark' : 'light';
+      } catch (error) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+
 </head>
 
 <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,12 +6,32 @@ import { useLanguage } from './context/LanguageContext.jsx';
 const NavBar = lazy(() => import('./components/Navbar'));
 const Footer = lazy(() => import('./components/Footer'));
 
+const THEME_STORAGE_KEY = 'portfolio-theme';
+
 const App = () => {
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    const storedPreference = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (storedPreference) {
+      return storedPreference === 'dark';
+    }
+
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    return prefersDark ?? true;
+  });
   const { language, locales } = useLanguage();
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', darkMode);
+    if (typeof document === 'undefined') return;
+
+    const root = document.documentElement;
+    root.classList.toggle('dark', darkMode);
+    root.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    root.style.colorScheme = darkMode ? 'dark' : 'light';
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(THEME_STORAGE_KEY, darkMode ? 'dark' : 'light');
+    }
   }, [darkMode]);
 
   const toggleTheme = () => setDarkMode((prev) => !prev);
@@ -30,7 +50,7 @@ const App = () => {
           <NavBar darkMode={darkMode} onToggleTheme={toggleTheme} />
         </Suspense>
 
-        <main className="flex-1 pt-28 md:pt-32">
+        <main className="w-full flex-1 pt-28 md:pt-32">
           <Router />
         </main>
 

--- a/src/assets/images/CVGenio/cvgenio-cover.svg
+++ b/src/assets/images/CVGenio/cvgenio-cover.svg
@@ -1,0 +1,52 @@
+<svg width="1200" height="900" viewBox="0 0 1200 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="200" y1="80" x2="1000" y2="820" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0F172A" />
+      <stop offset="0.5" stop-color="#111827" />
+      <stop offset="1" stop-color="#020617" />
+    </linearGradient>
+    <radialGradient id="halo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(600 420) scale(420)">
+      <stop offset="0" stop-color="#FACC15" stop-opacity="0.7" />
+      <stop offset="1" stop-color="#FACC15" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="lamp" x1="540" y1="520" x2="660" y2="670" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE047" />
+      <stop offset="1" stop-color="#F97316" />
+    </linearGradient>
+    <linearGradient id="base" x1="520" y1="640" x2="680" y2="740" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FB923C" />
+      <stop offset="1" stop-color="#EA580C" />
+    </linearGradient>
+    <filter id="shadow" x="420" y="640" width="360" height="120" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="24" result="blur" />
+    </filter>
+  </defs>
+  <rect width="1200" height="900" rx="64" fill="url(#bgGradient)" />
+  <circle cx="600" cy="420" r="420" fill="url(#halo)" />
+  <g opacity="0.45">
+    <path d="M180 260C300 220 420 280 520 300C660 330 800 300 960 220" stroke="#2563EB" stroke-width="20" stroke-linecap="round" stroke-opacity="0.3" />
+    <path d="M220 460C340 420 460 460 580 480C720 500 840 460 980 380" stroke="#22D3EE" stroke-width="16" stroke-linecap="round" stroke-opacity="0.25" />
+    <path d="M260 640C360 600 480 620 600 640C760 664 880 624 960 560" stroke="#A855F7" stroke-width="14" stroke-linecap="round" stroke-opacity="0.22" />
+  </g>
+  <g transform="translate(0 -32)">
+    <circle cx="600" cy="360" r="120" fill="#1F2937" stroke="#38BDF8" stroke-width="10" />
+    <path d="M600 250C636 250 666 280 666 316V340C666 370 642 394 612 394H588C558 394 534 370 534 340V316C534 280 564 250 600 250Z" fill="#0EA5E9" />
+    <path d="M600 272C576 272 556 292 556 316V332C556 356 574 374 598 374H602C626 374 644 356 644 332V316C644 292 624 272 600 272Z" fill="#38BDF8" />
+    <path d="M560 350C560 350 574 404 600 404C626 404 640 350 640 350" stroke="#F8FAFC" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <g filter="url(#shadow)" opacity="0.35">
+    <ellipse cx="600" cy="700" rx="140" ry="32" fill="#000000" />
+  </g>
+  <g>
+    <path d="M468 560C452 560 440 572 440 588C440 604 452 616 468 616H540C570 616 594 640 594 670V684H606V670C606 640 630 616 660 616H732C748 616 760 604 760 588C760 572 748 560 732 560H468Z" fill="url(#lamp)" />
+    <path d="M540 628H660C672 628 682 638 682 650C682 662 672 672 660 672H540C528 672 518 662 518 650C518 638 528 628 540 628Z" fill="url(#base)" />
+    <path d="M512 692H688C700 692 710 700 712 712C716 732 700 748 680 748H520C500 748 484 732 488 712C490 700 500 692 512 692Z" fill="#F97316" />
+    <path d="M596 556L568 520C556 504 560 484 580 476C588 472 596 470 604 470C612 470 620 472 628 476C648 484 652 504 640 520L612 556H596Z" fill="#FACC15" />
+    <path d="M604 484C588 484 576 496 576 512C576 528 588 540 604 540C620 540 632 528 632 512C632 496 620 484 604 484Z" fill="#FEF3C7" />
+  </g>
+  <g transform="translate(0, 128)">
+    <rect x="360" y="540" width="480" height="120" rx="60" fill="#020617" stroke="#38BDF8" stroke-width="4" />
+    <text x="600" y="610" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700" letter-spacing="2" fill="#F8FAFC">CVGenio</text>
+    <text x="600" y="650" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="24" font-weight="500" letter-spacing="3" fill="#38BDF8">AI-POWERED RESUME LAB</text>
+  </g>
+</svg>

--- a/src/assets/images/placeholders/preview-slot.svg
+++ b/src/assets/images/placeholders/preview-slot.svg
@@ -1,0 +1,16 @@
+<svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="944" height="524" rx="40" fill="url(#bg)" stroke="#38BDF8" stroke-width="4" stroke-dasharray="20 16" stroke-linecap="round" />
+  <defs>
+    <linearGradient id="bg" x1="120" y1="60" x2="840" y2="460" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1120" />
+      <stop offset="0.45" stop-color="#0F172A" />
+      <stop offset="1" stop-color="#1E293B" />
+    </linearGradient>
+  </defs>
+  <g fill="#38BDF8" opacity="0.85">
+    <circle cx="480" cy="210" r="64" fill="#1E293B" stroke="#38BDF8" stroke-width="6" />
+    <path d="M480 170C498 170 512 184 512 202V216C512 232 500 244 484 244H476C460 244 448 232 448 216V202C448 184 462 170 480 170Z" fill="#0EA5E9" />
+    <path d="M480 188C470 188 462 196 462 206V214C462 224 470 232 480 232C490 232 498 224 498 214V206C498 196 490 188 480 188Z" fill="#38BDF8" />
+  </g>
+  <rect x="264" y="340" width="432" height="64" rx="32" fill="#0F172A" opacity="0.45" />
+</svg>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -35,9 +35,9 @@ const NavBar = ({ darkMode, onToggleTheme }) => {
       initial={{ opacity: 0, y: -24 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
-      className="fixed inset-x-0 top-4 z-40 flex justify-center px-4"
+      className="fixed inset-x-0 top-4 z-40 flex justify-center px-3 sm:px-4"
     >
-      <div className="w-full max-w-6xl">
+      <div className="w-full max-w-6xl xl:max-w-7xl">
         <div className="relative">
           <div className="absolute inset-0 rounded-3xl bg-white/60 blur-sm dark:bg-slate-900/60" />
           <nav className="relative flex items-center justify-between gap-4 rounded-3xl border border-white/50 bg-white/80 px-5 py-3 shadow-brand backdrop-blur-md dark:border-white/10 dark:bg-slate-900/80">

--- a/src/components/SubFooter.jsx
+++ b/src/components/SubFooter.jsx
@@ -9,7 +9,7 @@ const SubFooter = () => {
   const whatsappLink = locales[language].links.whatsapp;
 
   return (
-    <section className="px-4">
+    <section className="px-4 sm:px-6 lg:px-12">
       <motion.div
         initial={{ opacity: 0, y: 24 }}
         whileInView={{ opacity: 1, y: 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 }
 
 a {
@@ -11,12 +11,14 @@ a {
 }
 
 body {
+  width: 100%;
   min-height: 100vh;
   margin: 0;
   background: linear-gradient(180deg, rgba(248,250,252,1) 0%, rgba(255,255,255,1) 40%, rgba(244,244,255,1) 100%);
   color: #0f172a;
   font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   letter-spacing: 0.01em;
+  overflow-x: hidden;
 }
 
 .dark body {
@@ -26,4 +28,45 @@ body {
 
 p {
   text-align: justify;
+}
+
+img,
+video {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.image-gallery,
+.image-gallery-content,
+.image-gallery-slide-wrapper {
+  width: 100%;
+}
+
+.image-gallery-slide .image-gallery-image {
+  border-radius: 1.25rem;
+  background-color: rgba(15, 23, 42, 0.7);
+  padding: 1rem;
+}
+
+.image-gallery-thumbnail {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background-color: rgba(15, 23, 42, 0.6);
+}
+
+.image-gallery-thumbnail.active,
+.image-gallery-thumbnail:hover {
+  border-color: rgba(56, 189, 248, 0.6);
+}
+
+.image-gallery-thumbnails-wrapper {
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .image-gallery-thumbnails-container {
+    gap: 0.5rem;
+  }
 }

--- a/src/locales/locales.js
+++ b/src/locales/locales.js
@@ -86,6 +86,10 @@ export const locales = {
         'Explora el repositorio para revisar el código, las decisiones técnicas y el roadmap.',
       notFoundTitle: 'Proyecto no encontrado',
       notFoundAction: 'Volver a proyectos',
+      previewPlaceholderTitle: 'Preview pendiente',
+      previewPlaceholderDescription: 'Reservé este espacio para subir nuevas capturas en cuanto estén listas.',
+      previewPlaceholderShort: 'Próximamente',
+      previewAltLabel: 'Vista previa',
     },
     about: {
       description:
@@ -171,6 +175,46 @@ export const locales = {
       vite: 'Vite',
     },
     projectsData: {
+      cvgenio: {
+        title: 'CVGenio',
+        description:
+          'SPA en React 19 + TypeScript para crear, optimizar y administrar CVs con experiencias asistidas, sincronización multicanal y generación PDF profesional.',
+        heroImageAlt: 'Ilustración del laboratorio CVGenio con foco en currículums asistidos por IA',
+        details: [
+          {
+            title: 'Arquitectura frontend',
+            items: [
+              'Aplicación de una sola página montada con Vite y React Router 7, cargando módulos perezosos para wizard, dashboards y análisis.',
+              'Árbol de providers que inicializa autenticación JWT, asistentes del wizard, toasts y control de suscripción desde el arranque.',
+              'Shell persistente con Navbar, SubNavbar y Footer que asegura navegación consistente y accesible.',
+            ],
+          },
+          {
+            title: 'Experiencia del usuario',
+            items: [
+              'Interfaz responsiva construida con Tailwind, styled-components y framer-motion para animaciones suaves.',
+              'Wizard modular con vistas de edición, previsualización PDF y sugerencias IA en paralelo.',
+              'Persistencia local de borradores con sincronización debounced para evitar pérdida de datos entre pestañas.',
+            ],
+          },
+          {
+            title: 'Servicios y datos',
+            items: [
+              'Consumo de API Java Spring bajo ${API_BASE}/api con autenticación JWT y endpoints de CV, IA y suscripciones.',
+              'Hooks dedicados para normalizar payloads, validar créditos y orquestar flujos premium antes de llamar al backend.',
+              'Generación de documentos PDF con plantillas profesionales y compatibilidad con Google reCAPTCHA v3.',
+            ],
+          },
+          {
+            title: 'Calidad y despliegue',
+            items: [
+              'Suite de pruebas con Jest 30 y Testing Library para lógica crítica y componentes.',
+              'Cypress listo para flujos end-to-end y ESLint con TypeScript ESLint para asegurar estándares.',
+              'Builds específicas por entorno (dev/test/prod) mediante scripts de Vite y despliegue estático en CDN.',
+            ],
+          },
+        ],
+      },
       portfolioV1: {
         title: 'Portafolio V1',
         description:
@@ -285,6 +329,10 @@ export const locales = {
         'Browse the repository to review the source code, technical decisions, and roadmap.',
       notFoundTitle: 'Project not found',
       notFoundAction: 'Back to projects',
+      previewPlaceholderTitle: 'Preview coming soon',
+      previewPlaceholderDescription: 'This slot is ready to host the next set of screenshots as soon as they are available.',
+      previewPlaceholderShort: 'Coming soon',
+      previewAltLabel: 'Preview',
     },
     about: {
       description:
@@ -370,6 +418,46 @@ export const locales = {
       vite: 'Vite',
     },
     projectsData: {
+      cvgenio: {
+        title: 'CVGenio',
+        description:
+          'React 19 + TypeScript SPA that guides users through CV creation, optimisation and management with assisted flows, multi-tab sync and polished PDF exports.',
+        heroImageAlt: 'CVGenio lab illustration focused on AI-assisted résumé workflows',
+        details: [
+          {
+            title: 'Frontend architecture',
+            items: [
+              'Single-page application bootstrapped with Vite and React Router 7, lazy-loading wizard, dashboards and analytics modules.',
+              'Provider tree initialises JWT authentication, wizard assistants, toasts and subscription guards from the very first render.',
+              'Persistent application shell with Navbar, SubNavbar and Footer to ensure consistent and accessible navigation.',
+            ],
+          },
+          {
+            title: 'User experience',
+            items: [
+              'Responsive interface powered by Tailwind, styled-components and framer-motion for refined animations.',
+              'Modular wizard that combines editing panels, PDF previews and AI suggestions side-by-side.',
+              'Local draft persistence with debounced sync to protect user data across tabs and devices.',
+            ],
+          },
+          {
+            title: 'Services & data',
+            items: [
+              'Java Spring API consumption under ${API_BASE}/api with JWT auth plus CV, AI and subscription endpoints.',
+              'Dedicated hooks to normalise payloads, validate credits and orchestrate premium flows before reaching the backend.',
+              'Professional PDF generation plus Google reCAPTCHA v3 to secure recovery and registration forms.',
+            ],
+          },
+          {
+            title: 'Quality & delivery',
+            items: [
+              'Jest 30 + Testing Library suites covering critical logic and UI components.',
+              'Cypress ready for end-to-end coverage and ESLint with TypeScript ESLint enforcing code standards.',
+              'Environment-specific Vite builds (dev/test/prod) prepared for CDN-ready static deployments.',
+            ],
+          },
+        ],
+      },
       portfolioV1: {
         title: 'Portfolio V1',
         description:

--- a/src/pages/AboutMe/AboutMe.jsx
+++ b/src/pages/AboutMe/AboutMe.jsx
@@ -8,7 +8,7 @@ const AboutMe = () => {
   const aboutCopy = locales[language].about;
 
   return (
-    <section id="AboutMe" className="px-4 pb-24 pt-16 sm:pt-20">
+    <section id="AboutMe" className="px-4 pb-24 pt-16 sm:px-6 sm:pt-20 lg:px-12">
       <div className="mx-auto w-full max-w-5xl">
         <div className="mx-auto max-w-2xl text-center">
           <span className="inline-flex items-center justify-center rounded-full bg-brand-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-700 dark:bg-brand-500/10 dark:text-brand-200">

--- a/src/pages/Homepage/Welcome.jsx
+++ b/src/pages/Homepage/Welcome.jsx
@@ -8,14 +8,14 @@ const Welcome = () => {
   const { hero, documents, links, brand } = locales[language];
 
   return (
-    <section className="relative isolate px-4 pb-24 pt-12 sm:pt-16">
+    <section className="relative isolate px-4 pb-24 pt-12 sm:px-6 sm:pt-16 lg:px-12">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute left-1/4 top-0 h-64 w-64 rounded-full bg-brand-400/20 blur-[150px]" />
         <div className="absolute right-0 top-1/3 h-80 w-80 rounded-full bg-accent-300/20 blur-[170px]" />
         <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-brand-700/10 blur-[160px]" />
       </div>
 
-      <div className="mx-auto grid w-full max-w-6xl items-center gap-12 lg:grid-cols-[minmax(0,1.1fr),minmax(0,0.9fr)]">
+      <div className="mx-auto grid w-full max-w-6xl items-center gap-12 lg:grid-cols-[minmax(0,1.1fr),minmax(0,0.9fr)] xl:max-w-7xl">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}

--- a/src/pages/Projects/Projects.jsx
+++ b/src/pages/Projects/Projects.jsx
@@ -12,7 +12,7 @@ const Projects = () => {
   const copy = locales[language].projectsSection;
 
   return (
-    <section id="Projects" className="px-4 pb-24 pt-12 sm:pt-16">
+    <section id="Projects" className="px-4 pb-24 pt-12 sm:px-6 sm:pt-16 lg:px-12">
       <div className="mx-auto w-full max-w-6xl">
         <motion.div
           initial={{ opacity: 0, y: 24 }}
@@ -33,7 +33,7 @@ const Projects = () => {
           </p>
         </motion.div>
 
-        <div className="mt-12 grid gap-8 lg:grid-cols-2">
+        <div className="mt-12 grid gap-8 lg:grid-cols-2 xl:grid-cols-3">
           {projects.map((project, index) => (
             <motion.article
               key={project.title}
@@ -46,8 +46,8 @@ const Projects = () => {
               <div className="relative overflow-hidden rounded-3xl">
                 <img
                   src={project.image}
-                  alt={project.title}
-                  className="h-48 w-full rounded-3xl object-cover transition duration-500 group-hover:scale-105"
+                  alt={project.heroImageAlt ?? project.title}
+                  className="h-48 w-full rounded-3xl object-cover transition duration-500 group-hover:scale-105 sm:h-56"
                 />
                 <div className="pointer-events-none absolute inset-0 rounded-3xl bg-gradient-to-tr from-brand-950/70 via-brand-700/0 to-transparent opacity-0 transition duration-500 group-hover:opacity-100" />
                 <div className="pointer-events-none absolute bottom-4 left-4 right-4 flex items-center justify-between text-white opacity-0 transition duration-500 group-hover:opacity-100">

--- a/src/pages/Projects/components/Data.jsx
+++ b/src/pages/Projects/components/Data.jsx
@@ -1,5 +1,6 @@
 // src/data/projectData.jsx
 
+import cvgenioCover from '../../../assets/images/CVGenio/cvgenio-cover.svg';
 import alfateamLogo from '../../../assets/images/AlfaTeam/alfaTeamLogo.webp';
 import alfateam1 from '../../../assets/images/AlfaTeam/1.webp';
 import alfateam2 from '../../../assets/images/AlfaTeam/2.webp';
@@ -54,6 +55,29 @@ import sgu6 from '../../../assets/images/PortalSGU/sgu6.png';
 import sgu7 from '../../../assets/images/PortalSGU/sgu7.png';
 
 const projectAssets = [
+  {
+    key: 'cvgenio',
+    image: cvgenioCover,
+    link: null,
+    technologies: [
+      'React 19',
+      'TypeScript',
+      'Vite',
+      'React Router DOM v7',
+      'Tailwind CSS',
+      'Styled-components',
+      'Framer Motion',
+      'Context API',
+      'React Hook Form',
+      'Axios',
+      'Jest',
+      'Cypress',
+    ],
+    screenshots: [
+      { original: cvgenioCover, thumbnail: cvgenioCover },
+    ],
+    previewSlots: 5,
+  },
   {
     key: 'portfolioV1',
     image: portfolioOldLogo,
@@ -185,5 +209,7 @@ export const getProjects = (locales, language) =>
       ...project,
       title: copy.title,
       description: copy.description,
+      ...(copy.heroImageAlt ? { heroImageAlt: copy.heroImageAlt } : {}),
+      ...(copy.details ? { details: copy.details } : {}),
     };
   });

--- a/src/pages/Projects/components/ProjectPage.jsx
+++ b/src/pages/Projects/components/ProjectPage.jsx
@@ -5,6 +5,7 @@ import { slugify } from '../../../utils/slugify';
 import { motion } from 'framer-motion';
 import ImageGallery from 'react-image-gallery';
 import 'react-image-gallery/styles/css/image-gallery.css';
+import previewSlot from '../../../assets/images/placeholders/preview-slot.svg';
 
 const ProjectPage = () => {
   const { language, locales } = useLanguage();
@@ -22,7 +23,7 @@ const ProjectPage = () => {
 
   if (!project) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4 text-center">
+      <div className="flex min-h-screen items-center justify-center px-4 py-20 text-center sm:px-6 lg:px-12">
         <div className="max-w-md rounded-3xl border border-brand-100 bg-white/90 p-10 text-neutral-700 shadow-lg dark:border-brand-500/20 dark:bg-slate-900/80 dark:text-neutral-200">
           <p className="text-2xl font-semibold">{projectCopy.notFoundTitle}</p>
           <button
@@ -37,8 +38,68 @@ const ProjectPage = () => {
     );
   }
 
+  const previewAltPrefix = projectCopy.previewAltLabel ?? 'Preview';
+
+  const normalizedScreenshots = (project.screenshots ?? []).map((item, index) => ({
+    ...item,
+    originalAlt: `${project.title} ${previewAltPrefix} ${index + 1}`,
+    key: `screenshot-${index}`,
+  }));
+  const totalSlots = Math.max(project.previewSlots ?? normalizedScreenshots.length, normalizedScreenshots.length);
+  const placeholderCount = Math.max(totalSlots - normalizedScreenshots.length, 0);
+  const placeholderItems = Array.from({ length: placeholderCount }, (_, index) => ({
+    original: previewSlot,
+    thumbnail: previewSlot,
+    isPlaceholder: true,
+    key: `placeholder-${index}`,
+  }));
+  const galleryItems = [...normalizedScreenshots, ...placeholderItems];
+
+  const renderGalleryItem = (item) => {
+    if (item.isPlaceholder) {
+      return (
+        <div className="flex min-h-[260px] items-center justify-center rounded-3xl bg-slate-900/60 p-6 text-center dark:bg-slate-950/70">
+          <div className="space-y-2">
+            <p className="text-lg font-semibold text-brand-200">{projectCopy.previewPlaceholderTitle}</p>
+            <p className="text-sm text-neutral-300">{projectCopy.previewPlaceholderDescription}</p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <figure className="flex min-h-[260px] w-full items-center justify-center overflow-hidden rounded-3xl bg-slate-900/50 p-3">
+        <img
+          src={item.original}
+          alt={item.originalAlt ?? project.heroImageAlt ?? project.title}
+          loading="lazy"
+          className="h-full w-full max-w-full rounded-2xl object-contain"
+        />
+      </figure>
+    );
+  };
+
+  const renderThumbnail = (item) => {
+    if (item.isPlaceholder) {
+      return (
+        <div className="flex h-full w-full items-center justify-center rounded-xl bg-slate-900/70 text-[10px] font-semibold uppercase tracking-wide text-brand-200">
+          {projectCopy.previewPlaceholderShort}
+        </div>
+      );
+    }
+
+    return (
+      <img
+        src={item.thumbnail}
+        alt={item.originalAlt ?? project.heroImageAlt ?? project.title}
+        loading="lazy"
+        className="h-full w-full rounded-xl object-cover"
+      />
+    );
+  };
+
   return (
-    <section className="px-4 pb-24 pt-24 sm:pt-28">
+    <section className="px-4 pb-24 pt-24 sm:px-6 sm:pt-28 lg:px-12">
       <div className="mx-auto w-full max-w-5xl space-y-10">
         <motion.div
           initial={{ opacity: 0, y: 32 }}
@@ -66,15 +127,45 @@ const ProjectPage = () => {
               </span>
             ))}
           </div>
+
+          {project.details?.length ? (
+            <div className="mt-8 grid gap-4 rounded-3xl border border-neutral-200/60 bg-white/80 p-4 text-left dark:border-slate-700 dark:bg-slate-900/60 sm:grid-cols-2">
+              {project.details.map((section) => (
+                <div
+                  key={section.title}
+                  className="flex flex-col gap-3 rounded-2xl border border-white/60 bg-white/70 p-4 dark:border-white/10 dark:bg-slate-950/40"
+                >
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-brand-600 dark:text-brand-200">
+                    {section.title}
+                  </h3>
+                  <ul className="space-y-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
+                    {section.items.map((item) => (
+                      <li key={item} className="flex gap-2">
+                        <span className="mt-1 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-brand-500" />
+                        <span className="flex-1">{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          ) : null}
         </motion.div>
 
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.55, ease: 'easeOut', delay: 0.1 }}
-          className="overflow-hidden rounded-4xl border border-neutral-200/80 bg-white/90 shadow-lg dark:border-slate-700 dark:bg-slate-900/80"
+          className="overflow-hidden rounded-4xl border border-neutral-200/80 bg-white/90 p-4 shadow-lg dark:border-slate-700 dark:bg-slate-900/80 sm:p-6"
         >
-          <ImageGallery items={project.screenshots} showPlayButton={false} showFullscreenButton={false} thumbnailPosition="bottom" />
+          <ImageGallery
+            items={galleryItems}
+            showPlayButton={false}
+            showFullscreenButton={false}
+            thumbnailPosition="bottom"
+            renderItem={renderGalleryItem}
+            renderThumbInner={renderThumbnail}
+          />
         </motion.div>
 
         {project.link && (


### PR DESCRIPTION
## Summary
- set the dark theme as the default experience, persist the preference, and tune global gallery styles for better responsiveness
- add the CVGenio project with localized copy, preview placeholders, and dedicated artwork
- adjust portfolio sections and navigation spacing to tighten rendering across mobile and desktop breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69095a90b41c832e90c8b5cc48d0d2ef